### PR TITLE
disable parse5 entity escaping in generation of template strings

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1,16 +1,28 @@
-const {parseFragment, serialize} = require('parse5');
+const {parseFragment} = require('parse5');
+const Serializer = require('parse5/lib/serializer');
 
 const TYPES = ['style', 'script', 'template'];
 
-module.exports = text => parseFragment(text)
-	.childNodes
-	.filter(node => TYPES.includes(node.nodeName))
-	.reduce((acc, node) => {
-		acc[node.nodeName] = {
-			tag: node.nodeName,
-			attrs: node.attrs,
-			value: node.childNodes.length > 0 ? node.childNodes[0].value : serialize(node.content)
-		};
+module.exports = text => {
+	// don't change >, <, &, " to html entities in this context
+	const coreEscape = Serializer.escapeString;
+	Serializer.escapeString = str => str;
 
-		return acc;
-	}, {});
+	const parsed = parseFragment(text)
+		.childNodes
+		.filter(node => TYPES.includes(node.nodeName))
+		.reduce((acc, node) => {
+			const serializer = new Serializer(node.content);
+			acc[node.nodeName] = {
+				tag: node.nodeName,
+				attrs: node.attrs,
+				value: node.childNodes.length > 0 ? node.childNodes[0].value : serializer.serialize()
+			};
+			return acc;
+		}, {});
+
+	// restore entity escaping in case it's needed elsewhere
+	Serializer.escapeString = coreEscape;
+
+	return parsed;
+}


### PR DESCRIPTION
Let me know if you'd prefer the string-replace method and I'll modify the PR. I like this for addressing the issue more precisely, but it is more brittle.