### PR TITLE
Update for lit-element 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ module: {
 <template>
   <div>
     <p>
-      Clicked: <span>${props.clicks}</span> times.
-      Value is <span>${props.value}</span>.
-      <button on-click="${() => this._onIncrement()}" title="Add 1">+</button>
-      <button on-click="${() => this._onDecrement()}" title="Minus 1">-</button>
+      Clicked: <span>${this.clicks}</span> times.
+      Value is <span>${this.value}</span>.
+      <button @click="${this._onIncrement}" title="Add 1">+</button>
+      <button @click="${this._onDecrement}" title="Minus 1">-</button>
     </p>
   </div>
 </template>
@@ -103,7 +103,7 @@ module: {
 
 `index.js`
 ```js
-import {LitElement, html} from '@polymer/lit-element';
+import {LitElement, html} from 'lit-element';
 
 ...
 

--- a/src/enrich.js
+++ b/src/enrich.js
@@ -1,14 +1,14 @@
 const j = require('jscodeshift');
 
 const renderTemplate = templateString => `
-	_render(props) {
+	render() {
 		return html\`${templateString}\`
 	}
 `.replace(/\t/gi, '');
 
 const addLitReferences = source => j(source)
 	.find(j.ExportDefaultDeclaration)
-	.insertBefore('import {LitElement, html} from \'@polymer/lit-element\'')
+	.insertBefore('import {LitElement, html} from \'lit-element\'')
 	.find(j.Identifier)
 	.at(0)
 	.forEach(item => j(item).replaceWith(`${item.node.name} extends LitElement`))

--- a/test/enrich.test.js
+++ b/test/enrich.test.js
@@ -20,8 +20,8 @@ ${SCRIPT}
 	const {style, template, script} = parser(content);
 	const enriched = m(script.value, `<style>${style.value}</style>${template.value}`);
 
-	t.true(enriched.includes('import {LitElement, html} from \'@polymer/lit-element\''), 'Includes import LitElement');
+	t.true(enriched.includes('import {LitElement, html} from \'lit-element\''), 'Includes import LitElement');
 	t.true(enriched.includes('CounterElement extends LitElement {'), 'Includes extends LitElement');
-	t.true(enriched.includes('_render(props)'), 'Includes render function');
+	t.true(enriched.includes('render()'), 'Includes render function');
 	t.true(enriched.includes('return html`'), 'Includes return html function');
 });


### PR DESCRIPTION
[LitElement release candidate](https://www.polymer-project.org/blog/2019-01-11-lit-element-rc) is published to the unscoped lit-element npm package.

I changed [example repository](https://github.com/sizuhiko/lit-loader-example/tree/lit-element-2) too.

I will send pull request about the example after merge this PR.
Because [lit-loader on the example refers my forked repository now](https://github.com/sizuhiko/lit-loader-example/commit/d577e5f44d4563f3a629ebfe1bd1c78b97cd47d5#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R38).
